### PR TITLE
2주차. 여러 개의 복구 버튼을 한 개의 되돌리기 버튼으로 바꾸기

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import TitleFieldContainer from './components/TitleFieldContainer';
 import Task from './components/Task';
 import Header from './components/Header';
 import LogBookContainer from './components/LogBookContainer';
+import RestoreTaskButton from './components/RestoreTaskButton';
 
 const Grid = styled.div({
   display: 'grid',
@@ -52,6 +53,7 @@ export default function App() {
         <FieldWapper>
           <Header />
           <TitleFieldContainer />
+          <RestoreTaskButton />
         </FieldWapper>
         <TasksWapper>
           <Task id={0} />

--- a/src/components/LogBook.jsx
+++ b/src/components/LogBook.jsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 
 import { original } from '../color';
-import RestoreTaskButton from './RestoreTaskButton';
 import depthCalcutaor from '../depthCalculator';
 
 const DeletedItem = styled.li({
@@ -24,7 +23,6 @@ export default function LogBook({ deletedTasks }) {
             {'#'.repeat(depthInfo[selfId])}
             {' '}
             {task.title}
-            <RestoreTaskButton id={selfId} />
           </DeletedItem>
         </div>
       ))}

--- a/src/components/LogBook.test.jsx
+++ b/src/components/LogBook.test.jsx
@@ -34,10 +34,4 @@ describe('LogBook', () => {
     expect(container).toHaveTextContent('# task2');
     expect(container).toHaveTextContent('## task3');
   });
-
-  it('renders "복구" button', () => {
-    const { getAllByRole } = renderLogBook();
-
-    expect(getAllByRole('button', { name: '복구' })).toHaveLength(recentDeleted.length);
-  });
 });

--- a/src/components/LogBookContainer.test.jsx
+++ b/src/components/LogBookContainer.test.jsx
@@ -83,12 +83,6 @@ describe('LogBookContainer', () => {
         expect(container).toHaveTextContent('## task3');
       });
 
-      it('renders "복구" button', () => {
-        const { getAllByRole } = renderLogBookContainer();
-
-        expect(getAllByRole('button', { name: '복구' })).toHaveLength(recentDeleted.length);
-      });
-
       it('renders "로그 닫기" button', () => {
         const { getByRole } = renderLogBookContainer();
 

--- a/src/components/RestoreTaskButton.jsx
+++ b/src/components/RestoreTaskButton.jsx
@@ -3,16 +3,16 @@ import { useDispatch } from 'react-redux';
 import { restoreTask } from '../redux_module/todoSlice';
 import ActionButton from '../styled/ActionButton';
 
-export default function RestoreTaskButton({ id }) {
+export default function RestoreTaskButton() {
   const dispatch = useDispatch();
-  const handleClick = () => dispatch(restoreTask(id));
+  const handleClick = () => dispatch(restoreTask());
 
   return (
     <ActionButton
       type="button"
       onClick={handleClick}
     >
-      복구
+      되돌리기
     </ActionButton>
   );
 }

--- a/src/components/RestoreTaskButton.test.jsx
+++ b/src/components/RestoreTaskButton.test.jsx
@@ -16,13 +16,11 @@ describe('RestoreTask', () => {
     useDispatch.mockReturnValue(dispatch);
   });
 
-  it('renders "복구" button listening click event', () => {
-    const id = 1;
+  it('renders "되돌리기" button listening click event', () => {
+    const { getByRole } = render(<RestoreTaskButton />);
 
-    const { getByRole } = render(<RestoreTaskButton id={id} />);
+    fireEvent.click(getByRole('button', { name: '되돌리기' }));
 
-    fireEvent.click(getByRole('button', { name: '복구' }));
-
-    expect(dispatch).toBeCalledWith(restoreTask(id));
+    expect(dispatch).toBeCalledWith(restoreTask());
   });
 });

--- a/src/redux_module/todoSlice.js
+++ b/src/redux_module/todoSlice.js
@@ -71,19 +71,13 @@ const { actions, reducer } = createSlice({
       });
     },
 
-    restoreTask: (state, action) => {
-      const { recentDeleted } = state;
-      const { payload: targetId } = action;
-
-      const isDataToRestore = R.propEq('selfId', targetId);
-
-      const restoreData = R.find(isDataToRestore, recentDeleted);
+    restoreTask: (state) => {
+      const restoreData = state.recentDeleted.pop();
 
       const { task, selfId, parentId } = restoreData;
 
       state.tasks[selfId] = task;
       state.tasks[parentId].subTasks.push(selfId);
-      state.recentDeleted = R.reject(isDataToRestore, recentDeleted);
     },
 
     updateSelectedTaskId: (state, action) => {

--- a/src/redux_module/todoSlice.js
+++ b/src/redux_module/todoSlice.js
@@ -72,6 +72,10 @@ const { actions, reducer } = createSlice({
     },
 
     restoreTask: (state) => {
+      if (state.recentDeleted.length === 0) {
+        return;
+      }
+
       const restoreData = state.recentDeleted.pop();
 
       const { task, selfId, parentId } = restoreData;

--- a/src/redux_module/todoSlice.test.js
+++ b/src/redux_module/todoSlice.test.js
@@ -120,19 +120,19 @@ describe('todoSlice reducer', () => {
       };
 
       const newState = {
-        recentDeleted: [restoreData2],
+        recentDeleted: [restoreData1],
         selectedTaskId: 0,
         nextTaskId: 4,
         tasks: {
-          0: { title: 'root', subTasks: [3, 1], isOpen: true },
-          1: { title: '첫번째 할일', subTasks: [], isOpen: true },
+          0: { title: 'root', subTasks: [3, 2], isOpen: true },
+          2: { title: '두번째 할일', subTasks: [], isOpen: true },
           3: { title: '세번째 할일', subTasks: [], isOpen: true },
         },
       };
 
       expect(reducer(
         oldState,
-        restoreTask(1),
+        restoreTask(),
       )).toEqual(newState);
     });
 

--- a/src/redux_module/todoSlice.test.js
+++ b/src/redux_module/todoSlice.test.js
@@ -96,44 +96,62 @@ describe('todoSlice reducer', () => {
   });
 
   describe('restoreTask', () => {
-    it('retores deleted task with id', () => {
-      const restoreData1 = {
-        task: { title: '첫번째 할일', subTasks: [], isOpen: true },
-        selfId: 1,
-        parentId: 0,
-      };
+    context("when there aren't any deleted task", () => {
+      it('does nothing', () => {
+        const oldState = {
+          recentDeleted: [],
+          selectedTaskId: 0,
+          nextTaskId: 4,
+          tasks: {
+            0: { title: 'root', subTasks: [3], isOpen: true },
+            3: { title: '세번째 할일', subTasks: [], isOpen: true },
+          },
+        };
 
-      const restoreData2 = {
-        task: { title: '두번째 할일', subTasks: [], isOpen: true },
-        selfId: 2,
-        parentId: 0,
-      };
+        expect(oldState).toEqual(oldState);
+      });
+    });
 
-      const oldState = {
-        recentDeleted: [restoreData1, restoreData2],
-        selectedTaskId: 0,
-        nextTaskId: 4,
-        tasks: {
-          0: { title: 'root', subTasks: [3], isOpen: true },
-          3: { title: '세번째 할일', subTasks: [], isOpen: true },
-        },
-      };
+    context('when there are deleted tasks', () => {
+      it('retores deleted task with id', () => {
+        const restoreData1 = {
+          task: { title: '첫번째 할일', subTasks: [], isOpen: true },
+          selfId: 1,
+          parentId: 0,
+        };
 
-      const newState = {
-        recentDeleted: [restoreData1],
-        selectedTaskId: 0,
-        nextTaskId: 4,
-        tasks: {
-          0: { title: 'root', subTasks: [3, 2], isOpen: true },
-          2: { title: '두번째 할일', subTasks: [], isOpen: true },
-          3: { title: '세번째 할일', subTasks: [], isOpen: true },
-        },
-      };
+        const restoreData2 = {
+          task: { title: '두번째 할일', subTasks: [], isOpen: true },
+          selfId: 2,
+          parentId: 0,
+        };
 
-      expect(reducer(
-        oldState,
-        restoreTask(),
-      )).toEqual(newState);
+        const oldState = {
+          recentDeleted: [restoreData1, restoreData2],
+          selectedTaskId: 0,
+          nextTaskId: 4,
+          tasks: {
+            0: { title: 'root', subTasks: [3], isOpen: true },
+            3: { title: '세번째 할일', subTasks: [], isOpen: true },
+          },
+        };
+
+        const newState = {
+          recentDeleted: [restoreData1],
+          selectedTaskId: 0,
+          nextTaskId: 4,
+          tasks: {
+            0: { title: 'root', subTasks: [3, 2], isOpen: true },
+            2: { title: '두번째 할일', subTasks: [], isOpen: true },
+            3: { title: '세번째 할일', subTasks: [], isOpen: true },
+          },
+        };
+
+        expect(reducer(
+          oldState,
+          restoreTask(),
+        )).toEqual(newState);
+      });
     });
 
     describe('updateSelectedTaskId', () => {

--- a/test/restore_test.js
+++ b/test/restore_test.js
@@ -10,15 +10,19 @@ Scenario('Can restore deleted tasks', ({ I }) => {
   I.fillField('할 일', '두 번째 할 일');
   I.click('추가');
 
-  I.click('//*[@id="app"]/div/div[2]/ul/li[1]/button[2]');
-  I.click('완료');
+  I.click('//*[@id="app"]/div/div[2]/ul/li[2]/button[2]');
+  I.click('//*[@id="app"]/div/div[2]/ul/li/button[2]');
 
   I.click('로그 열기');
+  I.see('# 첫 번째 할 일');
+  I.see('# 두 번째 할 일');
+  I.click('로그 닫기');
+
+  I.click('되돌리기');
+  I.see('첫 번째 할 일');
+  I.dontSee('두 번째 할 일');
+
+  I.click('되돌리기');
   I.see('첫 번째 할 일');
   I.see('두 번째 할 일');
-
-  I.click('//*[@id="app"]/div/div[3]/ul/div[2]/li/button');
-  I.click('로그 닫기');
-  I.see('두 번째 할 일');
-  I.dontSee('첫 번째 할 일');
 });


### PR DESCRIPTION
수정 이전: 삭제한 테스크 하나에 복구 버튼 하나
수정 이후: 입력 필드 옆에 되돌리기 버튼 하나

이전에는 외관상으로도 좋지 않고, 하위의 테스크가 복구되지 않았을 때 상위 테스크를 복구하려고 할 경우 정상적으로 작동하지 않는 복잡한 문제를 야기했습니다. 그리고 기능적으로도 각 테스트 하나하나를 복구해야할 필요가 크지 않은 것 같습니다. 필요한 경우 직접 다시 입력하면 되기 때문입니다.

따라서 되돌리기 버튼 하나만을 제공해 가장 최근에 삭제한 테스크부터 하나하나 복원하도록 했습니다.