### PR TITLE
2주차: index.jsx에서 ThemeProvider를 사용해 색상을 정하고, 테스트 일부를 삭제하라

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -1,2 +1,14 @@
-export const original = '#a2b8de';
-export const highlight = '#356ccc';
+const palette = {
+  primary: {
+    main: '#7986cb',
+    dark: '#49599a',
+    light: '#aab6fe',
+  },
+  secondary: {
+    main: '#c5cae9',
+    dark: '#9499b7',
+    light: '#f8fdff',
+  },
+};
+
+export default palette;

--- a/src/components/Header.test.jsx
+++ b/src/components/Header.test.jsx
@@ -4,27 +4,12 @@
 
 import { render } from '@testing-library/react';
 
-import { highlight, original } from '../color';
 import Header from './Header';
 
 describe('Header', () => {
-  context('when root is selected', () => {
-    it('renders header with highlight color', () => {
-      const { getByText } = render(<Header initialTaskId={0} />);
+  it('renders header', () => {
+    const { getByText } = render(<Header initialTaskId={0} />);
 
-      expect(getByText('Tresk')).toHaveStyle({
-        color: highlight,
-      });
-    });
-  });
-
-  context('when task is selected', () => {
-    it('renders header with original color', () => {
-      const { getByText } = render(<Header initialTaskId={1} />);
-
-      expect(getByText('Tresk')).toHaveStyle({
-        color: original,
-      });
-    });
+    expect(getByText('Tresk')).toBeInTheDocument();
   });
 });

--- a/src/components/TaskTitle.test.jsx
+++ b/src/components/TaskTitle.test.jsx
@@ -5,7 +5,6 @@
 import { fireEvent, render } from '@testing-library/react';
 import given from 'given2';
 
-import { highlight, original } from '../color';
 import TaskTitle from './TaskTitle';
 
 describe('TaskTitle', () => {
@@ -37,29 +36,5 @@ describe('TaskTitle', () => {
     fireEvent.click(getByRole('button', { name: title }));
 
     expect(handleClick).toBeCalled();
-  });
-
-  context('when task is selected', () => {
-    given('isSelected', () => true);
-
-    it('renders button with highlight color', () => {
-      const { getByRole } = renderTaskTitle();
-
-      expect(getByRole('button', { name: title })).toHaveStyle({
-        color: highlight,
-      });
-    });
-  });
-
-  context('when task is not selected', () => {
-    given('isSelected', () => false);
-
-    it('renders button with original color', () => {
-      const { getByRole } = renderTaskTitle();
-
-      expect(getByRole('button', { name: 'taskTitle' })).toHaveStyle({
-        color: original,
-      });
-    });
   });
 });

--- a/src/components/TaskTitleContainer.test.jsx
+++ b/src/components/TaskTitleContainer.test.jsx
@@ -6,7 +6,6 @@ import { fireEvent, render } from '@testing-library/react';
 import { useDispatch, useSelector } from 'react-redux';
 import given from 'given2';
 
-import { highlight, original } from '../color';
 import { updateSelectedTaskId } from '../redux_module/todoSlice';
 import TaskTitleContainer from './TaskTitleContainer';
 
@@ -28,30 +27,6 @@ describe('TaskTitleContainer', () => {
         },
       },
     }));
-  });
-
-  context('when currentTaskId == selectedTaskId', () => {
-    given('selectedTaskId', () => 1);
-
-    it('renders button with highlight color', () => {
-      const { getByRole } = render(<TaskTitleContainer id={currentTaskId} />);
-
-      expect(getByRole('button', { name: 'task1' })).toHaveStyle({
-        color: highlight,
-      });
-    });
-  });
-
-  context('when currentTaskId != selectedTaskId', () => {
-    given('selectedTaskId', () => 0);
-
-    it('renders button with original color', () => {
-      const { getByRole } = render(<TaskTitleContainer id={currentTaskId} />);
-
-      expect(getByRole('button', { name: 'task1' })).toHaveStyle({
-        color: original,
-      });
-    });
   });
 
   it('updates selected task id to current task id on click event', () => {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,17 +2,28 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
 import { persistStore } from 'redux-persist';
+import { createMuiTheme, ThemeProvider } from '@material-ui/core';
 
 import store from './redux_module/store';
+import palette from './color';
 import App from './App';
 
 const persistor = persistStore(store);
+
+const theme = createMuiTheme({
+  palette,
+  // fontFamily: font,
+});
 
 ReactDOM.render(
   (
     <Provider store={store}>
       <PersistGate loading={null} persistor={persistor}>
-        <App />
+        <ThemeProvider
+          theme={theme}
+        >
+          <App />
+        </ThemeProvider>
       </PersistGate>
     </Provider>
   ),


### PR DESCRIPTION
`Material UI`를 사용하면서 `ThemeProvider`로 `primary`와 `secondary` 를 정의하여 사용합니다.

그런데 이렇게 하면 `toHaveStyle`로 색상을 테스트 할 수 없습니다. [관련 이슈](https://github.com/testing-library/jest-dom/issues/350)

이 부분은 잘 변경되는 부분이 아니기도 하고, 이 테스트가 없어도 코드에 대한 신뢰에 큰 차이가 없다고 판단하여 지웠습니다.