### PR TITLE
2주차. toggleLogBookOpen가 인자를 받을 수 있도록 하라

### DIFF
--- a/src/redux_module/todoSlice.js
+++ b/src/redux_module/todoSlice.js
@@ -96,8 +96,12 @@ const { actions, reducer } = createSlice({
       state.tasks[id].isOpen = !isOpen;
     },
 
-    toggleLogBookOpen: (state) => {
-      state.isLogBookOpen = !state.isLogBookOpen;
+    toggleLogBookOpen: (state, action) => {
+      const { payload: want } = action;
+
+      state.isLogBookOpen = (want === undefined)
+        ? !state.isLogBookOpen
+        : want;
     },
 
     resetRecentDeleted: (state) => {

--- a/src/redux_module/todoSlice.test.js
+++ b/src/redux_module/todoSlice.test.js
@@ -237,18 +237,48 @@ describe('todoSlice reducer', () => {
     });
 
     describe('toggleLogBookOpen', () => {
-      it('toggles isLogBookOpen', () => {
-        const oldState = {
-          isLogBookOpen: false,
-        };
+      context('when 0 argument is given', () => {
+        it('toggles isLogBookOpen', () => {
+          const oldState = {
+            isLogBookOpen: false,
+          };
 
-        const newState = {
-          isLogBookOpen: true,
-        };
-        expect(reducer(
-          oldState,
-          toggleLogBookOpen(),
-        )).toEqual(newState);
+          const newState = {
+            isLogBookOpen: true,
+          };
+          expect(reducer(
+            oldState,
+            toggleLogBookOpen(),
+          )).toEqual(newState);
+        });
+      });
+
+      context('when 1 argument is given', () => {
+        it('sets isLogBookOpen', () => {
+          const oldState1 = {
+            isLogBookOpen: true,
+          };
+
+          const newState1 = {
+            isLogBookOpen: true,
+          };
+          expect(reducer(
+            oldState1,
+            toggleLogBookOpen(true),
+          )).toEqual(newState1);
+
+          const oldState2 = {
+            isLogBookOpen: false,
+          };
+
+          const newState2 = {
+            isLogBookOpen: false,
+          };
+          expect(reducer(
+            oldState2,
+            toggleLogBookOpen(false),
+          )).toEqual(newState2);
+        });
       });
     });
   });


### PR DESCRIPTION
기존에는 `toggleLogBookOpen`이 인자를 받지 않고 불리언 값을 반대로 바꾸기만 했지만, 이제는 선택적으로 인자를 받아 인자가 주어질 시 주어진 값으로 불리언 값을 바꿉니다.