### PR TITLE
항상 id 내림차순으로 task를 subTasks에 저장하도록 하라

### DIFF
--- a/src/components/SubTasks.jsx
+++ b/src/components/SubTasks.jsx
@@ -9,7 +9,7 @@ export default function SubTasks({ isOpen, subTasks }) {
 
   return (
     <ul>
-      {[...subTasks].sort().map((taskId) => (
+      {subTasks.map((taskId) => (
         <li key={taskId}>
           <Task id={taskId} />
         </li>

--- a/src/components/SubTasks.test.jsx
+++ b/src/components/SubTasks.test.jsx
@@ -13,7 +13,7 @@ describe('SubTasks', () => {
     render((
       <SubTasks
         isOpen={given.isOpen}
-        subTasks={[2, 3, 1]}
+        subTasks={[3, 2, 1]}
       />
     ))
   );
@@ -33,14 +33,14 @@ describe('SubTasks', () => {
   context('when subTasks are opened', () => {
     given('isOpen', () => true);
 
-    it('renders tasks in order', () => {
+    it('renders task in order', () => {
       const { getAllByRole } = renderSubTasks();
 
       const tasks = getAllByRole('listitem');
 
-      [0, 1, 2].forEach((index) => {
-        expect(tasks[index]).toHaveTextContent(`task${index + 1}`);
-      });
+      expect(tasks[0]).toHaveTextContent('task3');
+      expect(tasks[1]).toHaveTextContent('task2');
+      expect(tasks[2]).toHaveTextContent('task1');
     });
   });
 

--- a/src/components/SubTasksContainer.test.jsx
+++ b/src/components/SubTasksContainer.test.jsx
@@ -13,7 +13,7 @@ describe('SubTasksContainer', () => {
     useSelector.mockImplementation((selector) => selector({
       todo: {
         tasks: {
-          1: { title: 'task1', subTasks: [2, 3], isOpen: given.isOpen },
+          1: { title: 'task1', subTasks: [3, 2], isOpen: given.isOpen },
           2: { title: 'task2', subTasks: [], isOpen: true },
           3: { title: 'task3', subTasks: [], isOpen: true },
         },

--- a/src/components/Task.test.jsx
+++ b/src/components/Task.test.jsx
@@ -17,7 +17,7 @@ describe('Task', () => {
     useSelector.mockImplementation((selector) => selector({
       todo: {
         tasks: {
-          0: { title: 'root', subTasks: [1, 2], isOpen: true },
+          0: { title: 'root', subTasks: [2, 1], isOpen: true },
           1: { title: 'task1', subTasks: [], isOpen: true },
           2: { title: 'task2', subTasks: [3], isOpen: true },
           3: { title: 'task3', subTasks: [4], isOpen: true },

--- a/src/redux_module/todoSlice.js
+++ b/src/redux_module/todoSlice.js
@@ -38,7 +38,7 @@ const { actions, reducer } = createSlice({
 
       state.tasks[nextTaskId] = newTask;
 
-      state.tasks[selectedTaskId].subTasks.push(nextTaskId);
+      state.tasks[selectedTaskId].subTasks.unshift(nextTaskId);
 
       state.nextTaskId = nextTaskId + 1;
     },
@@ -80,9 +80,10 @@ const { actions, reducer } = createSlice({
       const restoreData = state.recentDeleted.pop();
 
       const { task, selfId, parentId } = restoreData;
+      const { subTasks } = state.tasks[parentId];
 
       state.tasks[selfId] = task;
-      state.tasks[parentId].subTasks.push(selfId);
+      state.tasks[parentId].subTasks = [...subTasks, selfId].sort().reverse();
     },
 
     updateSelectedTaskId: (state, action) => {

--- a/src/redux_module/todoSlice.test.js
+++ b/src/redux_module/todoSlice.test.js
@@ -15,7 +15,7 @@ describe('todoSlice reducer', () => {
       it('adds new task to todoList and updates nextTaskId', () => {
         const oldState = {
           recentDeleted: [],
-          selectedTaskId: 1,
+          selectedTaskId: 0,
           nextTaskId: 2,
           tasks: {
             0: { title: 'root', subTasks: [1], isOpen: true },
@@ -24,11 +24,11 @@ describe('todoSlice reducer', () => {
         };
         const newState = {
           recentDeleted: [],
-          selectedTaskId: 1,
+          selectedTaskId: 0,
           nextTaskId: 3,
           tasks: {
-            0: { title: 'root', subTasks: [1], isOpen: true },
-            1: { title: 'task1', subTasks: [2], isOpen: true },
+            0: { title: 'root', subTasks: [2, 1], isOpen: true },
+            1: { title: 'task1', subTasks: [], isOpen: true },
             2: { title: 'task2', subTasks: [], isOpen: true },
           },
         };
@@ -146,19 +146,19 @@ describe('todoSlice reducer', () => {
           parentId: 0,
         };
 
-        const restoreData2 = {
-          task: { title: '두번째 할일', subTasks: [], isOpen: true },
-          selfId: 2,
+        const restoreData3 = {
+          task: { title: '세번째 할일', subTasks: [], isOpen: true },
+          selfId: 3,
           parentId: 0,
         };
 
         const oldState = {
-          recentDeleted: [restoreData1, restoreData2],
+          recentDeleted: [restoreData1, restoreData3],
           selectedTaskId: 0,
           nextTaskId: 4,
           tasks: {
-            0: { title: 'root', subTasks: [3], isOpen: true },
-            3: { title: '세번째 할일', subTasks: [], isOpen: true },
+            0: { title: 'root', subTasks: [2], isOpen: true },
+            2: { title: '두번째 할일', subTasks: [], isOpen: true },
           },
         };
 


### PR DESCRIPTION
기존에 오름차순으로 해줬는데, 이제는 내림차순으로 렌더합니다.

이를 구현하는 것은 간단히 `reverse`문 하나로 처리할 수 있지만, 추후 추가할 기능을 염두에 두고 구현 방식을 변경했습니다.

이제 `task`는 항상 `id` 내림차순으로 `subTasks`에 저장됩니다.