### PR TITLE
3주차. 키보드 화살표 상하 키로 테스크 선택을 옮기는 기능을 구현하라

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,28 @@
 import { Route, Switch } from 'react-router-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
 
+import { useDispatch } from 'react-redux';
+import { selectNext, selectPrevious } from './redux_module/todoSlice';
+import useGlobalDOMEvents from './hook';
+
 import Intro from './Page/Intro';
 import Main from './Page/Main';
 
 export default function App() {
+  const dispatch = useDispatch();
+
+  useGlobalDOMEvents({
+    keydown(e) {
+      const notFound = () => null;
+
+      const bindings = {
+        ArrowUp: () => dispatch(selectPrevious()),
+        ArrowDown: () => dispatch(selectNext()),
+      };
+
+      (bindings[e.key] ?? notFound)();
+    },
+  });
   return (
     <>
       <CssBaseline />

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -2,16 +2,22 @@
  * @jest-environment jsdom
  */
 
-import { render } from '@testing-library/react';
-import { useSelector } from 'react-redux';
+import { fireEvent, render } from '@testing-library/react';
+import { useDispatch, useSelector } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 
 import App from './App';
+import { selectNext, selectPrevious } from './redux_module/todoSlice';
 
 jest.mock('react-p5-wrapper');
 
 describe('App', () => {
+  const dispatch = jest.fn();
+
   beforeEach(() => {
+    dispatch.mockClear();
+    useDispatch.mockReturnValue(dispatch);
+
     useSelector.mockImplementation((selector) => selector({
       todo: {
         completedTasks: [],
@@ -24,11 +30,25 @@ describe('App', () => {
     }));
   });
 
-  it('renders', () => {
+  it('listens to ArrowUp keyDown events', () => {
     render(
       <MemoryRouter>
         <App />
       </MemoryRouter>,
     );
+
+    fireEvent.keyDown(window, { key: 'ArrowUp', code: 'ArrowUp' });
+    expect(dispatch).toBeCalledWith(selectPrevious());
+  });
+
+  it('listens to ArrowDown keyDown events', () => {
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>,
+    );
+
+    fireEvent.keyDown(window, { key: 'ArrowDown', code: 'ArrowDown' });
+    expect(dispatch).toBeCalledWith(selectNext());
   });
 });

--- a/src/hook.js
+++ b/src/hook.js
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+export default function useGlobalDOMEvents(props) {
+  useEffect(() => {
+    Object.entries(props).forEach(([key, func]) => {
+      window.addEventListener(key, func, false);
+    });
+
+    return () => {
+      Object.entries(props).forEach(([key, func]) => {
+        window.removeEventListener(key, func, false);
+      });
+    };
+  }, []);
+}

--- a/src/redux_module/todoSlice.test.js
+++ b/src/redux_module/todoSlice.test.js
@@ -7,6 +7,8 @@ import reducer,
   updateSelectedTaskId,
   emptyCompletedTasks,
   toggleLogBookOpen,
+  selectNext,
+  selectPrevious,
 } from './todoSlice';
 
 describe('todoSlice reducer', () => {
@@ -222,29 +224,33 @@ describe('todoSlice reducer', () => {
     });
 
     describe('updateSelectedTaskId', () => {
-      it('updates current task id', () => {
+      it('updates current task id and parent id', () => {
         const oldState = {
           completedTasks: [],
           selectedTaskId: 0,
-          nextTaskId: 2,
+          parentId: 0,
+          nextTaskId: 3,
           remainingTasks: {
             0: { title: 'root', subTasks: [1], isOpen: true },
-            1: { title: '첫번째 할일', subTasks: [], isOpen: true },
+            1: { title: 'task1', subTasks: [2], isOpen: true },
+            2: { title: 'task2', subTasks: [], isOpen: true },
           },
         };
         const newState = {
           completedTasks: [],
-          selectedTaskId: 1,
-          nextTaskId: 2,
+          selectedTaskId: 2,
+          parentId: 1,
+          nextTaskId: 3,
           remainingTasks: {
             0: { title: 'root', subTasks: [1], isOpen: true },
-            1: { title: '첫번째 할일', subTasks: [], isOpen: true },
+            1: { title: 'task1', subTasks: [2], isOpen: true },
+            2: { title: 'task2', subTasks: [], isOpen: true },
           },
         };
 
         expect(reducer(
           oldState,
-          updateSelectedTaskId(1),
+          updateSelectedTaskId(2),
         )).toEqual(newState);
       });
     });
@@ -320,6 +326,132 @@ describe('todoSlice reducer', () => {
             toggleLogBookOpen(false),
           )).toEqual(newState2);
         });
+      });
+    });
+  });
+
+  describe('selectNext', () => {
+    context('when selected task id is 0', () => {
+      it('does nothing', () => {
+        const oldState = {
+          selectedTaskId: 0,
+          parentId: 0,
+          remainingTasks: {
+            0: { title: 'root', subTasks: [], isOpen: true },
+          },
+        };
+
+        expect(reducer(
+          oldState,
+          selectNext(),
+        )).toEqual(oldState);
+      });
+    });
+
+    context('When boundaries are met', () => {
+      it('does nothing', () => {
+        const oldState = {
+          selectedTaskId: 1,
+          parentId: 0,
+          remainingTasks: {
+            0: { title: 'root', subTasks: [2, 1], isOpen: true },
+            1: { title: 'task1', subTasks: [], isOpen: true },
+            2: { title: 'task2', subTasks: [], isOpen: true },
+          },
+        };
+
+        expect(reducer(
+          oldState,
+          selectNext(),
+        )).toEqual(oldState);
+      });
+    });
+
+    context('When boundaries are not met', () => {
+      it('sets selectedTaskId to next id in subTasks', () => {
+        const oldState = {
+          selectedTaskId: 2,
+          parentId: 0,
+          remainingTasks: {
+            0: { title: 'root', subTasks: [2, 1], isOpen: true },
+          },
+        };
+
+        const newState = {
+          selectedTaskId: 1,
+          parentId: 0,
+          remainingTasks: {
+            0: { title: 'root', subTasks: [2, 1], isOpen: true },
+          },
+        };
+
+        expect(reducer(
+          oldState,
+          selectNext(),
+        )).toEqual(newState);
+      });
+    });
+  });
+
+  describe('selectPrevious', () => {
+    context('when selected task id is 0', () => {
+      it('does nothing', () => {
+        const oldState = {
+          selectedTaskId: 0,
+          parentId: 0,
+          remainingTasks: {
+            0: { title: 'root', subTasks: [], isOpen: true },
+          },
+        };
+
+        expect(reducer(
+          oldState,
+          selectNext(),
+        )).toEqual(oldState);
+      });
+    });
+
+    context('When boundaries are met', () => {
+      it('does nothing', () => {
+        const oldState = {
+          selectedTaskId: 2,
+          parentId: 0,
+          remainingTasks: {
+            0: { title: 'root', subTasks: [2, 1], isOpen: true },
+            1: { title: 'task1', subTasks: [], isOpen: true },
+            2: { title: 'task2', subTasks: [], isOpen: true },
+          },
+        };
+
+        expect(reducer(
+          oldState,
+          selectPrevious(),
+        )).toEqual(oldState);
+      });
+    });
+
+    context('When boundaries are not met', () => {
+      it('sets selectedTaskId to previous id in subTasks', () => {
+        const oldState = {
+          selectedTaskId: 1,
+          parentId: 0,
+          remainingTasks: {
+            0: { title: 'root', subTasks: [2, 1], isOpen: true },
+          },
+        };
+
+        const newState = {
+          selectedTaskId: 2,
+          parentId: 0,
+          remainingTasks: {
+            0: { title: 'root', subTasks: [2, 1], isOpen: true },
+          },
+        };
+
+        expect(reducer(
+          oldState,
+          selectPrevious(),
+        )).toEqual(newState);
       });
     });
   });


### PR DESCRIPTION
화살표 상하로는 같은 깊이에 있는 테스트 사이를 옮겨갈 수 있습니다. 다른 깊이로 가려면 지금은 마우스로 직접 클릭해줘야합니다.
화살표 좌우 키로 깊이를 변경하는 기능을 구현할 예정입니다.

현재 리덕스에서 `selectedTaskId`와 `parentId`를 함께 관리하고 있는데, 화살표 좌우 키 기능을 구현하면서 
```js
selected: {
  selfId: 1
  parentId: 0
}
```
같이 다른 구조로 변경할 예정입니다.