### PR TITLE
3주차.  addTask 리듀서 테스트 수정

### DIFF
--- a/src/redux_module/todoSlice.test.js
+++ b/src/redux_module/todoSlice.test.js
@@ -13,10 +13,9 @@ import reducer,
 
 describe('todoSlice reducer', () => {
   describe('addTask', () => {
-    context('when title is not empty string', () => {
+    context('when something is typed', () => {
       it('adds new task to todoList and updates nextTaskId', () => {
         const oldState = {
-          completedTasks: [],
           selectedTaskId: 0,
           nextTaskId: 2,
           remainingTasks: {
@@ -24,29 +23,27 @@ describe('todoSlice reducer', () => {
             1: { title: 'task1', subTasks: [], isOpen: true },
           },
         };
-        const newState = {
-          completedTasks: [],
-          selectedTaskId: 0,
-          nextTaskId: 3,
-          remainingTasks: {
-            0: { title: 'root', subTasks: [2, 1], isOpen: true },
-            1: { title: 'task1', subTasks: [], isOpen: true },
-            2: { title: 'task2', subTasks: [], isOpen: true },
-          },
-        };
 
-        expect(reducer(
-          oldState,
-          addTask('task2'),
-        )).toEqual(newState);
+        const newState = reducer(oldState, addTask('task2'));
+
+        const { nextTaskId, remainingTasks } = newState;
+
+        expect(remainingTasks['0'].subTasks).toEqual(
+          [2, 1],
+        );
+
+        expect(remainingTasks['2']).toEqual(
+          { title: 'task2', subTasks: [], isOpen: true },
+        );
+
+        expect(nextTaskId).toBe(2 + 1);
       });
     });
 
-    context('when title is empty string', () => {
+    context('when nothing is typed', () => {
       it('does nothing', () => {
         const oldState = {
-          completedTasks: [],
-          selectedTaskId: 1,
+          selectedTaskId: 0,
           nextTaskId: 2,
           remainingTasks: {
             0: { title: 'root', subTasks: [1], isOpen: true },
@@ -54,10 +51,9 @@ describe('todoSlice reducer', () => {
           },
         };
 
-        expect(reducer(
-          oldState,
-          addTask(''),
-        )).toEqual(oldState);
+        const newState = reducer(oldState, addTask(''));
+
+        expect(newState).toEqual(oldState);
       });
     });
   });


### PR DESCRIPTION
다음과 같은 부분을 염두에 두고 테스트를 고쳐봤습니다.

1. 단언 하나 하나가 이 테스트 코드가 무엇을 테스트 하는지, 또는 테스트 대상 코드가 하는 일이 무엇인지를 명확하게 드러내도록 했습니다.
예를 들어 아래 테스트가 그렇습니다. 
```js
expect(nextTaskId).toBe(2 + 1);
```
2. 무엇을 테스트 하는지를 테스트 설명에서 표현할 수도 있지만 그것보다는 왜 이렇게 테스트 하는지가 드러나도록 하는 것이 더 중요합니다.
3. 불필요한 코드는 전체적인 코드의 응집도를 낮추므로 코드를 이해하기 어렵게 합니다. 예를 들어 상태에 불필요한 필드를 남겨두면 리듀서가 무엇을 하는지 드러내는데 방해가 됩니다.
4. 더 적은 노력으로 이해할 수 있도록 노력해야합니다.
예를 들어
```js
   expect(reducer(
          oldState,
          addTask(''),
        )).toEqual(oldState);
```

위 코드가 무엇을 하는지는 리듀서 테스트를 작성해본 사람이라면 누구나 이해할만 하지만, 아래 코드보다는 더 많은 노력이 듭니다.

```js
 const newState = reducer(oldState, addTask(''));

 expect(newState).toEqual(oldState);
```


