### PR TITLE
3주차. emptyCompletedTask리듀서 테스트 수정

### DIFF
--- a/src/redux_module/todoSlice.test.js
+++ b/src/redux_module/todoSlice.test.js
@@ -97,24 +97,21 @@ describe('todoSlice reducer', () => {
   });
 
   describe('emptyCompletedTasks', () => {
-    const restoreData = {
-      task: { title: '첫번째 할일', subTasks: [], isOpen: true },
-      selfId: 1,
-      parentId: 0,
-    };
+    it('removes all items from completedTasks', () => {
+      const restoreData = {
+        task: { title: '첫번째 할일', subTasks: [], isOpen: true },
+        selfId: 1,
+        parentId: 0,
+      };
 
-    const oldState = {
-      completedTasks: [restoreData],
-    };
+      const oldState = {
+        completedTasks: [restoreData],
+      };
 
-    const newState = {
-      completedTasks: [],
-    };
+      const newState = reducer(oldState, emptyCompletedTasks());
 
-    expect(reducer(
-      oldState,
-      emptyCompletedTasks(),
-    )).toEqual(newState);
+      expect(newState.completedTasks).toEqual([]);
+    });
   });
 
   describe('restoreTask', () => {


### PR DESCRIPTION
기존에 작성해둔 `emptyCompletedTask` 테스트에 `describe`블럭만 있고 `it`블럭이 없어서 추가해주고, `completedTask`가 빈 배열이 된다는 의도가 드러나도록 단언을 수정했습니다.