### PR TITLE
3주차. 2자리 수 이상의 id를 가진 테스크를 삭제할 때 발생하는 버그 해결

### DIFF
--- a/src/redux_module/helper.js
+++ b/src/redux_module/helper.js
@@ -49,7 +49,7 @@ export function removeTaskFromRemaingTasks(state, targetId) {
   const { remainingTasks } = state;
 
   state.remainingTasks = omit(
-    toString(targetId),
+    [toString(targetId)],
     remainingTasks,
   );
 }

--- a/src/redux_module/todoSlice.test.js
+++ b/src/redux_module/todoSlice.test.js
@@ -60,9 +60,9 @@ describe('todoSlice reducer', () => {
       parentId: 1,
     };
 
-    const restoreDataOfTask2 = {
-      task: { title: 'task2', subTasks: [], isOpen: true },
-      selfId: 2,
+    const restoreDataOfTask23 = {
+      task: { title: 'task23', subTasks: [], isOpen: true },
+      selfId: 23,
       parentId: 1,
     };
 
@@ -72,26 +72,29 @@ describe('todoSlice reducer', () => {
       parentId: 1,
       remainingTasks: {
         0: { title: 'root', subTasks: [1], isOpen: true },
-        1: { title: 'task1', subTasks: [2, 3], isOpen: true },
+        1: { title: 'task1', subTasks: [23, 3, 2], isOpen: true },
         2: { title: 'task2', subTasks: [], isOpen: true },
         3: { title: 'task3', subTasks: [], isOpen: true },
+        23: { title: 'task23', subTasks: [], isOpen: true },
       },
     };
 
     it('deletes task with id', () => {
-      const newState = reducer(oldState, deleteTask(2));
+      const newState = reducer(oldState, deleteTask(23));
 
       const { remainingTasks } = newState;
 
-      expect(remainingTasks['2']).toBeUndefined();
+      expect(remainingTasks['23']).toBeUndefined();
+      expect(remainingTasks['2']).not.toBeUndefined();
+      expect(remainingTasks['3']).not.toBeUndefined();
 
       expect(
-        remainingTasks['1'].subTasks.includes(2),
+        remainingTasks['1'].subTasks.includes(23),
       ).toBe(false);
     });
 
     it('resets selectedTaskId and parentId', () => {
-      const newState = reducer(oldState, deleteTask(2));
+      const newState = reducer(oldState, deleteTask(23));
 
       const { selectedTaskId, parentId } = newState;
 
@@ -100,15 +103,15 @@ describe('todoSlice reducer', () => {
     });
 
     it('adds restore data', () => {
-      const newState = reducer(oldState, deleteTask(2));
+      const newState = reducer(oldState, deleteTask(23));
 
       const { completedTasks } = newState;
 
       expect(completedTasks).toEqual(
-        [restoreDataOfTask4, restoreDataOfTask2],
+        [restoreDataOfTask4, restoreDataOfTask23],
       );
       expect(completedTasks).not.toEqual(
-        [restoreDataOfTask2, restoreDataOfTask4],
+        [restoreDataOfTask23, restoreDataOfTask4],
       );
     });
   });


### PR DESCRIPTION
`R.omit`은 첫번째 인자로 객체에서 삭제하고 싶은 키들의 배열을 받습니다. 그런데 리팩터링 과정에서 배열이 아니라 그냥 키(예를 들어 `['2']`가 아니라 그냥 `'2'`)를 넘겨도 테스트가 깨지지 않아 그렇게 바꿔줬었는데, 이것이 최근 간헐적으로 발생하던 버그의 원인임을 밝혀냈습니다.

`id`가 1자리수이면 문제가 없는데, 2자리수 이면 `R.omit('27', 객체)`는 27을 삭제하는게 아니라 2와 7을 삭제합니다.

다음과 같은 순서로 진행했습니다.

1. 어느 상황에 실패하는지에 대한 느낌을 얻은 뒤, 그것을 실패하는 테스트로 변환
2. 테스트가 통과하도록 `omit` 부분 코드 수정. 
3. 코드를 되돌린 뒤, 새로운 테스트를 삭제. 
4. 원래 테스트가 이 문제까지 포괄하도록 하고, 테스트가 깨지는 것을 확인.
5.  다시 `omit` 부분 코드를 고치고, 통과하는 것을 확인.