### PR TITLE
3주차. 키보드 좌우방향키로 선택한 할 일 변경 기능 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,10 @@
 import { Route, Switch } from 'react-router-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
-
 import { useDispatch } from 'react-redux';
-import { selectNext, selectPrevious } from './redux_module/todoSlice';
+
+import {
+  selectInside, selectNext, selectOutside, selectPrevious,
+} from './redux_module/todoSlice';
 import useGlobalDOMEvents from './hook';
 
 import Intro from './Page/Intro';
@@ -18,6 +20,8 @@ export default function App() {
       const bindings = {
         ArrowUp: () => dispatch(selectPrevious()),
         ArrowDown: () => dispatch(selectNext()),
+        ArrowLeft: () => dispatch(selectOutside()),
+        ArrowRight: () => dispatch(selectInside()),
       };
 
       (bindings[e.key] ?? notFound)();

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -6,8 +6,10 @@ import { fireEvent, render } from '@testing-library/react';
 import { useDispatch, useSelector } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 
+import {
+  selectInside, selectNext, selectOutside, selectPrevious,
+} from './redux_module/todoSlice';
 import App from './App';
-import { selectNext, selectPrevious } from './redux_module/todoSlice';
 
 jest.mock('react-p5-wrapper');
 
@@ -50,5 +52,27 @@ describe('App', () => {
 
     fireEvent.keyDown(window, { key: 'ArrowDown', code: 'ArrowDown' });
     expect(dispatch).toBeCalledWith(selectNext());
+  });
+
+  it('listens to ArrowLeft keyDown events', () => {
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>,
+    );
+
+    fireEvent.keyDown(window, { key: 'ArrowLeft', code: 'ArrowLeft' });
+    expect(dispatch).toBeCalledWith(selectOutside());
+  });
+
+  it('listens to ArrowRight keyDown events', () => {
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>,
+    );
+
+    fireEvent.keyDown(window, { key: 'ArrowRight', code: 'ArrowRight' });
+    expect(dispatch).toBeCalledWith(selectInside());
   });
 });

--- a/src/redux_module/helper.js
+++ b/src/redux_module/helper.js
@@ -13,13 +13,19 @@ export const includesTarget = (array, target) => pipe(
   includes(target),
 );
 
+export const findParentWithId = (tasks, id) => {
+  const result = find(
+    includesTarget(tasks, id),
+    keys(tasks),
+  );
+
+  return parseInt(result, 10);
+};
+
 export function removeTaskIdFromParentSubTasks(state, target) {
   const { remainingTasks } = state;
 
-  const parentId = find(
-    includesTarget(remainingTasks, target),
-    keys(remainingTasks),
-  );
+  const parentId = findParentWithId(remainingTasks, target);
 
   const { subTasks } = state.remainingTasks[parentId];
 
@@ -31,10 +37,7 @@ export function removeTaskIdFromParentSubTasks(state, target) {
 export function addRestoreData(state, target) {
   const { remainingTasks } = state;
 
-  const parentId = find(
-    includesTarget(remainingTasks, target),
-    keys(remainingTasks),
-  );
+  const parentId = findParentWithId(remainingTasks, target);
 
   const restoreData = {
     task: remainingTasks[target],

--- a/src/redux_module/todoSlice.js
+++ b/src/redux_module/todoSlice.js
@@ -10,6 +10,7 @@ import {
   addRestoreData,
   removeTaskIdFromParentSubTasks,
   removeTaskFromRemaingTasks,
+  findParentWithId,
 } from './helper';
 
 const initialState = {
@@ -142,6 +143,30 @@ const { actions, reducer } = createSlice({
 
       state.selectedTaskId = subTasks[currentIndex - 1];
     },
+
+    selectInside: (state) => {
+      const { selectedTaskId, remainingTasks } = state;
+
+      if (isEmpty(remainingTasks[selectedTaskId].subTasks)) {
+        return;
+      }
+
+      const { subTasks: [first] } = remainingTasks[selectedTaskId];
+
+      state.parentId = selectedTaskId;
+      state.selectedTaskId = first;
+    },
+
+    selectOutside: (state) => {
+      const { selectedTaskId, parentId, remainingTasks } = state;
+
+      if (selectedTaskId === 0) {
+        return;
+      }
+
+      state.selectedTaskId = parentId;
+      state.parentId = findParentWithId(remainingTasks, parentId);
+    },
   },
 });
 
@@ -155,6 +180,8 @@ export const {
   emptyCompletedTasks,
   selectNext,
   selectPrevious,
+  selectInside,
+  selectOutside,
 } = actions;
 
 export default reducer;

--- a/src/redux_module/todoSlice.test.js
+++ b/src/redux_module/todoSlice.test.js
@@ -9,6 +9,8 @@ import reducer,
   emptyCompletedTasks,
   selectNext,
   selectPrevious,
+  selectInside,
+  selectOutside,
 } from './todoSlice';
 
 describe('todoSlice reducer', () => {
@@ -428,6 +430,82 @@ describe('todoSlice reducer', () => {
         const { selectedTaskId } = newState;
 
         expect(selectedTaskId).toBe(2);
+      });
+    });
+  });
+
+  describe('selectInside', () => {
+    given('oldState', () => ({
+      selectedTaskId: given.selectedTaskId,
+      remainingTasks: {
+        0: { title: 'root', subTasks: [1], isOpen: true },
+        1: { title: 'task1', subTasks: [3, 2], isOpen: true },
+        2: { title: 'task2', subTasks: [], isOpen: true },
+        3: { title: 'task3', subTasks: [], isOpen: true },
+      },
+    }));
+
+    context('when there are no subTasks of current selected task', () => {
+      given('selectedTaskId', () => 2);
+
+      it('does nothing', () => {
+        const newState = reducer(given.oldState, selectInside());
+
+        expect(newState).toEqual(given.oldState);
+      });
+    });
+
+    context('when subTasks of current selected task exist', () => {
+      given('selectedTaskId', () => 1);
+
+      it('selects new task from subTasks', () => {
+        const newState = reducer(given.oldState, selectInside());
+
+        const { selectedTaskId, parentId } = newState;
+
+        expect(selectedTaskId).toBe(3);
+        expect(selectedTaskId).not.toBe(2);
+
+        expect(parentId).toBe(1);
+      });
+    });
+  });
+
+  describe('selectOutside', () => {
+    given('oldState', () => ({
+      selectedTaskId: given.selectedTaskId,
+      parentId: given.parentId,
+      remainingTasks: {
+        0: { title: 'root', subTasks: [1], isOpen: true },
+        1: { title: 'task1', subTasks: [3, 2], isOpen: true },
+        2: { title: 'task2', subTasks: [], isOpen: true },
+        3: { title: 'task3', subTasks: [], isOpen: true },
+      },
+    }));
+
+    context('when current selected task is top level task', () => {
+      given('selectedTaskId', () => 0);
+      given('parentId', () => 0);
+
+      it('does nothing', () => {
+        const newState = reducer(given.oldState, selectOutside());
+
+        expect(newState).toEqual(given.oldState);
+      });
+    });
+
+    context('when current selected task has parent task', () => {
+      given('selectedTaskId', () => 2);
+      given('parentId', () => 1);
+
+      it('selects parent task', () => {
+        const newState = reducer(given.oldState, selectOutside());
+
+        const { selectedTaskId, parentId } = newState;
+
+        expect(selectedTaskId).toBe(1);
+
+        expect(parentId).toBe(0);
       });
     });
   });


### PR DESCRIPTION
이제 키보드 좌우 방향키로 다른 깊이의 할 일을 선택할 수 있습니다.

리듀서를 작성하는 과정에서 아이디로 부모의 아이디를 찾는 함수가 필요해서 `helper.js`에서 이를 정의한 뒤, 리팩터링하고, 가져와서 사용했습니다.
